### PR TITLE
fix subfeed IDs to escape base64

### DIFF
--- a/format.js
+++ b/format.js
@@ -7,6 +7,7 @@ const bfe = require('ssb-bfe')
 const SSBURI = require('ssb-uri2')
 const varint = require('fast-varint')
 const ssbKeys = require('ssb-keys')
+const base64Url = require('base64-url')
 const makeContentHash = require('./content-hash')
 const {
   validate,
@@ -44,7 +45,7 @@ function getFeedId(nativeMsg) {
   const parent = bfe.decodeTypeFormat(parentBFE, 'message', 'buttwoo-v1')
   if (parent) {
     const { data } = SSBURI.decompose(parent)
-    const feedId = author + '/' + data
+    const feedId = author + '/' + base64Url.escape(data)
     _feedIdCache.set(nativeMsg, feedId)
     return feedId
   } else {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "!example.js"
   ],
   "dependencies": {
+    "base64-url": "^2.3.3",
     "bipf": "^1.7.0",
     "blake3": "^2.1.7",
     "fast-varint": "^1.0.1",

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,6 +6,7 @@ const tape = require('tape')
 const ssbKeys = require('ssb-keys')
 const bfe = require('ssb-bfe')
 const butt2 = require('../format')
+const uri2 = require('ssb-uri2')
 
 const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
 
@@ -88,6 +89,31 @@ tape('encode/decode works', function (t) {
   // test slow version as well
   const reconstructedButt2msg2 = butt2.toNativeMsg(jsonMsg2.value)
   t.deepEqual(reconstructedButt2msg2, butt2Msg2, 'can reconstruct')
+
+  t.end()
+})
+
+tape('subfeed id', function (t) {
+  const hmacKey = null
+  const content = { type: 'post', text: 'Hello world!' }
+  const timestamp = 1652037377204
+
+  const butt2Msg = butt2.newNativeMsg({
+    keys,
+    content,
+    parent:
+      'ssb:message/buttwoo-v1/bRjv4LV9CmJp-bXR1nOGJ9Uuo8glEBmnN27ckE2SFJo=',
+    previous: null,
+    timestamp,
+    tag: butt2.tags.SUB_FEED,
+    hmacKey,
+  })
+
+  const feedId = butt2.getFeedId(butt2Msg)
+  t.equals(
+    feedId,
+    'ssb:feed/buttwoo-v1/OAiOTCroL1xFxoCKYaZJDTxhLOHaI1cURm_HSPvEy7s=/bRjv4LV9CmJp-bXR1nOGJ9Uuo8glEBmnN27ckE2SFJo'
+  )
 
   t.end()
 })


### PR DESCRIPTION
## Context

ssb-ebt CI tests were intermittently failing. See https://github.com/ssbc/ssb-ebt/actions/runs/3255462256/jobs/5344803636

## Problem

For feed IDs like `ssb:feed/buttwoo-v1/FIRST/SECOND`, the `SECOND` part was **not** URL-escaped, and it should be.

## Solution

Make sure the SECOND part is escaped.

1st :x: 2nd :heavy_check_mark: 